### PR TITLE
 Change the cpu usage interval from second to minute

### DIFF
--- a/web/job/check_cpu_usage.go
+++ b/web/job/check_cpu_usage.go
@@ -23,7 +23,7 @@ func (j *CheckCpuJob) Run() {
 	threshold, _ := j.settingService.GetTgCpu()
 
 	// get latest status of server
-	percent, err := cpu.Percent(1*time.Second, false)
+	percent, err := cpu.Percent(1*time.Minute, false)
 	if err == nil && percent[0] > float64(threshold) {
 		msg := j.tgbotService.I18nBot("tgbot.messages.cpuThreshold",
 			"Percent=="+strconv.FormatFloat(percent[0], 'f', 2, 64),


### PR DESCRIPTION
Hi!

Now the Telegram bot sends a warning if CPU usage during the last second exceeds the threshold. This is quite useless because such small peaks can happen and do not affect system performance. However, what's more crucial is the CPU usage over a 1-minute period. It indicates that the system is busy for a significant amount of time, and you really should be warned.